### PR TITLE
Testing availability of Maven for CrawlerWrapper and dummy pom

### DIFF
--- a/pathfinder-server/src/main/java/org/aroundthecode/pathfinder/server/crawler/CrawlerWrapper.java
+++ b/pathfinder-server/src/main/java/org/aroundthecode/pathfinder/server/crawler/CrawlerWrapper.java
@@ -80,6 +80,14 @@ public class CrawlerWrapper {
 		return mvnHome;
 	}
 
+    public static Invoker getInvoker() {
+        return invoker;
+    }
+
+    public static File getFilePom() {
+        return filePom;
+    }
+
 	public void setMvnHome(String mvnHome) {
 		CrawlerWrapper.mvnHome = mvnHome;
 	}

--- a/pathfinder-server/src/test/java/org/aroundthecode/pathfinder/server/crawler/CrawlerWrapperTest.java
+++ b/pathfinder-server/src/test/java/org/aroundthecode/pathfinder/server/crawler/CrawlerWrapperTest.java
@@ -4,6 +4,7 @@ import org.apache.maven.shared.invoker.DefaultInvocationRequest;
 import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.Test;
+import org.junit.internal.ExactComparisonCriteria;
 
 import java.util.Collections;
 
@@ -20,9 +21,13 @@ public class CrawlerWrapperTest {
     @Test
     public void testMavenInstallation() {
 
+        System.out.println("CrawlerWrapperTest. Starting the test");
+
         DefaultInvocationRequest request = new DefaultInvocationRequest();
         request.setPomFile(CrawlerWrapper.getFilePom());
+        System.out.println("CrawlerWrapperTest. after setPomFile()");
         request.setGoals(Collections.singletonList("clean"));
+        System.out.println("CrawlerWrapperTest. after setGoals()");
 
         try {
             InvocationResult result = CrawlerWrapper.getInvoker().execute(request);
@@ -30,6 +35,8 @@ public class CrawlerWrapperTest {
             assertEquals("Maven invocation on dummy pom did not succeed", 0, result.getExitCode());
         } catch (MavenInvocationException e) {
             fail("CrawlerWrapper did not find Maven installation. " + e.toString());
+        } catch (RuntimeException rte) {
+            rte.printStackTrace();
         }
 
     }

--- a/pathfinder-server/src/test/java/org/aroundthecode/pathfinder/server/crawler/CrawlerWrapperTest.java
+++ b/pathfinder-server/src/test/java/org/aroundthecode/pathfinder/server/crawler/CrawlerWrapperTest.java
@@ -1,0 +1,37 @@
+package org.aroundthecode.pathfinder.server.crawler;
+
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class CrawlerWrapperTest {
+
+    /**
+     * This is a canary test of CrawlerWrapper setup.
+     * Fails if Maven installation is not found or there is a problem with dummy pom
+     */
+    @Test
+    public void testMavenInstallation() {
+
+        DefaultInvocationRequest request = new DefaultInvocationRequest();
+        request.setPomFile(CrawlerWrapper.getFilePom());
+        request.setGoals(Collections.singletonList("clean"));
+
+        try {
+            InvocationResult result = CrawlerWrapper.getInvoker().execute(request);
+            assertNull("Invocation resulted in exception. " + result.getExecutionException().toString(), result.getExecutionException());
+            assertEquals("Maven invocation on dummy pom did not succeed", 0, result.getExitCode());
+        } catch (MavenInvocationException e) {
+            fail("CrawlerWrapper did not find Maven installation. " + e.toString());
+        }
+
+    }
+
+}

--- a/pathfinder-server/src/test/java/org/aroundthecode/pathfinder/server/crawler/CrawlerWrapperTest.java
+++ b/pathfinder-server/src/test/java/org/aroundthecode/pathfinder/server/crawler/CrawlerWrapperTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 public class CrawlerWrapperTest {
@@ -25,9 +26,7 @@ public class CrawlerWrapperTest {
 
         try {
             InvocationResult result = CrawlerWrapper.getInvoker().execute(request);
-            if (result.getExecutionException() != null) {
-                fail("Invocation resulted in exception. " + result.getExecutionException());
-            }
+            assertNull("Invocation resulted in exception. " + result.getExecutionException(), result.getExecutionException());
             assertEquals("Maven invocation on dummy pom did not succeed", 0, result.getExitCode());
         } catch (MavenInvocationException e) {
             fail("CrawlerWrapper did not find Maven installation. " + e);

--- a/pathfinder-server/src/test/java/org/aroundthecode/pathfinder/server/crawler/CrawlerWrapperTest.java
+++ b/pathfinder-server/src/test/java/org/aroundthecode/pathfinder/server/crawler/CrawlerWrapperTest.java
@@ -4,12 +4,10 @@ import org.apache.maven.shared.invoker.DefaultInvocationRequest;
 import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.Test;
-import org.junit.internal.ExactComparisonCriteria;
 
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 public class CrawlerWrapperTest {
@@ -21,22 +19,18 @@ public class CrawlerWrapperTest {
     @Test
     public void testMavenInstallation() {
 
-        System.out.println("CrawlerWrapperTest. Starting the test");
-
         DefaultInvocationRequest request = new DefaultInvocationRequest();
         request.setPomFile(CrawlerWrapper.getFilePom());
-        System.out.println("CrawlerWrapperTest. after setPomFile()");
         request.setGoals(Collections.singletonList("clean"));
-        System.out.println("CrawlerWrapperTest. after setGoals()");
 
         try {
             InvocationResult result = CrawlerWrapper.getInvoker().execute(request);
-            assertNull("Invocation resulted in exception. " + result.getExecutionException().toString(), result.getExecutionException());
+            if (result.getExecutionException() != null) {
+                fail("Invocation resulted in exception" + result.getExecutionException().toString());
+            }
             assertEquals("Maven invocation on dummy pom did not succeed", 0, result.getExitCode());
         } catch (MavenInvocationException e) {
             fail("CrawlerWrapper did not find Maven installation. " + e.toString());
-        } catch (RuntimeException rte) {
-            rte.printStackTrace();
         }
 
     }

--- a/pathfinder-server/src/test/java/org/aroundthecode/pathfinder/server/crawler/CrawlerWrapperTest.java
+++ b/pathfinder-server/src/test/java/org/aroundthecode/pathfinder/server/crawler/CrawlerWrapperTest.java
@@ -26,11 +26,11 @@ public class CrawlerWrapperTest {
         try {
             InvocationResult result = CrawlerWrapper.getInvoker().execute(request);
             if (result.getExecutionException() != null) {
-                fail("Invocation resulted in exception" + result.getExecutionException().toString());
+                fail("Invocation resulted in exception. " + result.getExecutionException());
             }
             assertEquals("Maven invocation on dummy pom did not succeed", 0, result.getExitCode());
         } catch (MavenInvocationException e) {
-            fail("CrawlerWrapper did not find Maven installation. " + e.toString());
+            fail("CrawlerWrapper did not find Maven installation. " + e);
         }
 
     }


### PR DESCRIPTION
If `M2_HOME` is not set and maven is not found in default location the added test fails with
`testMavenInstallation(org.aroundthecode.pathfinder.server.crawler.CrawlerWrapperTest): CrawlerWrapper did not find Maven installation. org.apache.maven.shared.invoker.MavenInvocationException: Error configuring command-line. Reason: Maven executable not found at: /opt/apache-maven/bin/mvn`

This eases debugging
