### PR TITLE
Then returned value of saveArtifact method can be very large

### DIFF
--- a/pathfinder-server/src/main/java/org/aroundthecode/pathfinder/server/controller/PathFinderController.java
+++ b/pathfinder-server/src/main/java/org/aroundthecode/pathfinder/server/controller/PathFinderController.java
@@ -264,11 +264,11 @@ public class PathFinderController {
 	 * @throws ParseException if json is not parsable
 	 */
 	@RequestMapping(value="/node/save", method=RequestMethod.POST)
-	public Artifact saveArtifact(@RequestBody String body) throws ParseException 
+	public void saveArtifact(@RequestBody String body) throws ParseException 
 	{
 		JSONObject o = RestUtils.string2Json(body);
 		Artifact a = Artifact.parse(o);
-		return checkAndSaveArtifact(a);
+		checkAndSaveArtifact(a);
 	}
 
 	/**


### PR DESCRIPTION
We use pathfinder in our project. We have the problem to collect data for our modules (Projects with 17 main modules, with 3-4 submodules) 
RestUtils#sendPost(113) thows an OutOfMemory Error or "Exception in thread "main": java.lang.OutOfMemoryError: Requested array size exceeds VM limit" during the execution of this code: 
That means that the Internal Array Size of BufferedReader reached maximal size (2GB??)

Why saveArtifact Resource returns the Artifact that has some very big size? Plus tne return value of RestUtils#sendPost is never used. 
